### PR TITLE
로컬 스토리지 이용한 장바구니 구현

### DIFF
--- a/src/main/java/com/nhnacademy/hello/common/config/SecurityConfig.java
+++ b/src/main/java/com/nhnacademy/hello/common/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 logout ->
                         logout.logoutUrl("/logout")
                                 // 로그아웃 시 홈페이지로 이동
-                                .logoutSuccessUrl("/")
+                                .logoutSuccessUrl("/?clearLocalCart=true")
                                 .deleteCookies("token")
         );
 

--- a/src/main/java/com/nhnacademy/hello/controller/login/LoginController.java
+++ b/src/main/java/com/nhnacademy/hello/controller/login/LoginController.java
@@ -1,12 +1,10 @@
 package com.nhnacademy.hello.controller.login;
 
 import com.nhnacademy.hello.common.properties.JwtProperties;
-import com.nhnacademy.hello.dto.cart.CartDTO;
 import com.nhnacademy.hello.dto.member.LoginRequest;
 import com.nhnacademy.hello.common.feignclient.MemberAdapter;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,8 +15,6 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -65,7 +61,7 @@ public class LoginController {
 
 
         // 로그인 후 홈페이지로 이동
-        return "redirect:/";
+        return "redirect:/?loginSuccess=true";
     }
 
 

--- a/src/main/java/com/nhnacademy/hello/controller/login/LoginController.java
+++ b/src/main/java/com/nhnacademy/hello/controller/login/LoginController.java
@@ -61,7 +61,7 @@ public class LoginController {
 
 
         // 로그인 후 홈페이지로 이동
-        return "redirect:/?loginSuccess=true";
+        return "redirect:/?clearLocalCart=true";
     }
 
 

--- a/src/main/resources/templates/book/bookDetail.html
+++ b/src/main/resources/templates/book/bookDetail.html
@@ -62,17 +62,23 @@
 
 
 
-                <!-- 수량 선택 -->
+                <!-- 도서 정보 -->
+                <span id="bookId" style="display: none;" th:text="${book.bookId}"></span>
+                <span id="bookTitle" style="display: none;" th:text="${book.bookTitle}"></span>
+                <span id="bookPrice" style="display: none;" th:text="${book.bookPrice}"></span>
+
+                <!-- 수량 입력 -->
                 <div class="mb-3">
                     <label for="quantity" class="form-label">수량:</label>
-                    <input type="number" id="quantity" name="quantity" class="form-control w-25" min="1" max="10" value="1">
+                    <input type="number" id="quantity" class="form-control w-25" min="1" max="10" value="1" required>
                 </div>
 
-                <!-- 버튼들 -->
+                <!-- 버튼 -->
                 <div class="d-flex">
-                    <button type="button" class="btn btn-outline-success me-2" >장바구니 담기</button>
-                    <button type="button" class="btn btn-outline-danger" >바로 구매</button>
+                    <button id="addToCartButton" class="btn btn-outline-success me-2">장바구니 담기</button>
+                    <a href="/purchase" class="btn btn-outline-danger">바로 구매</a>
                 </div>
+
             </div>
         </div>
 
@@ -83,6 +89,40 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+
+    <script>
+        // 장바구니 담기 버튼 클릭 이벤트
+        document.getElementById("addToCartButton").addEventListener("click", function () {
+            // 현재 책 정보 가져오기
+            const bookId = document.getElementById("bookId").innerText;
+            const bookTitle = document.getElementById("bookTitle").innerText;
+            const bookPrice = document.getElementById("bookPrice").innerText;
+            const quantity = document.getElementById("quantity").value;
+
+            // 로컬스토리지에서 기존 장바구니 가져오기
+            let cart = JSON.parse(localStorage.getItem("cart")) || [];
+
+            // 이미 담긴 책인지 확인
+            const alreadyInCart = cart.some(item => item.bookId === bookId);
+            if (alreadyInCart) {
+                alert("이미 장바구니에 담긴 책입니다!");
+                return;
+            }
+
+            // 새 책 데이터를 추가
+            cart.push({
+                bookId: bookId,
+                bookTitle: bookTitle,
+                bookPrice: bookPrice,
+                quantity: quantity,
+            });
+
+            // 로컬스토리지에 저장
+            localStorage.setItem("cart", JSON.stringify(cart));
+
+            alert("장바구니에 추가되었습니다!");
+        });
+    </script>
 
 
 </body>

--- a/src/main/resources/templates/index/index.html
+++ b/src/main/resources/templates/index/index.html
@@ -73,16 +73,16 @@
 
 <script>
     window.onload = function() {
-        // URL에서 loginSuccess 파라미터가 있는지 확인
+        // URL에서 clearLocalCart 파라미터가 있는지 확인
         const urlParams = new URLSearchParams(window.location.search);
-        const loginSuccess = urlParams.get('loginSuccess');
+        const clearLocalCart = urlParams.get('clearLocalCart');
 
         // 로그인 성공 시 로컬 스토리지에서 cart 삭제
-        if (loginSuccess === 'true') {
+        if (clearLocalCart === 'true') {
             localStorage.removeItem("cart");
         }
 
-        // URL에서 loginSuccess 파라미터 제거
+        // URL에서 clearLocalCart 파라미터 제거
         history.replaceState(null, null, window.location.pathname);  // URL에서 파라미터 제거
 
     };

--- a/src/main/resources/templates/index/index.html
+++ b/src/main/resources/templates/index/index.html
@@ -69,5 +69,24 @@
     <!-- 풋터 -->
     <div th:replace="fragments/footer :: footer"></div>
 </div>
+
+
+<script>
+    window.onload = function() {
+        // URL에서 loginSuccess 파라미터가 있는지 확인
+        const urlParams = new URLSearchParams(window.location.search);
+        const loginSuccess = urlParams.get('loginSuccess');
+
+        // 로그인 성공 시 로컬 스토리지에서 cart 삭제
+        if (loginSuccess === 'true') {
+            localStorage.removeItem("cart");
+        }
+
+        // URL에서 loginSuccess 파라미터 제거
+        history.replaceState(null, null, window.location.pathname);  // URL에서 파라미터 제거
+
+    };
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
회원, 비회원 모두 로컬 스토리지를 이용해서 장바구니 저장 가능.
이미 담은 책은 안담김

로그인/ 로그아웃 시, 회원 - 비회원이 전환 되므로 장바구니가 초기화 됨.
장바구니 페이지에서 조회는 나현씨가 하는 중.
개발자도구 -> 로컬스토리지를 보면 직접 볼 수 있음.

원래 세션 기반으로 구현하려 했으나, 현재 jwt 토큰을 이용한 인증을 하고있기 때문에, 세션을 비활성 상태로 구현중이므로 장바구니 유지가 되지 않음.

회원은 로그인 시 api 통신으로 db에 저장된 장바구니 목록을 불러오는 것을 추가 구현 해야 함.